### PR TITLE
Update dependency version

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     ],
     "dependencies": {
         "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0",
         "elm-community/string-extra": "1.1.1 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0"


### PR DESCRIPTION
I just go this error during installation:
```
To install mdgriffith/style-elements I would like to add the following
dependency to elm-package.json:

    "mdgriffith/style-elements": "2.0.1 <= v < 3.0.0"

May I add that to elm-package.json for you? [Y/n] 

Error: I cannot find a set of packages that works with your constraints
```

So **List.Extra** has updated to version 5
The only breaking change is that they switched order of arguments to `andMap`
This shouldn't affect Style Elements at all, but should help elm-package
