### PR TITLE
Fix mistype in Element.el doc

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -270,7 +270,7 @@ You need to specify a style, a list of attributes, and a single child.
     -- an element with the style `MyStyle`, that is aligned left, and has one child.
     el MyStyle [ alignLeft ] (text "Hello World!")
 
-`el` can only have one child because in order to ahve multiple children, we need to specify how the layout would work.
+`el` can only have one child because in order to have multiple children, we need to specify how the layout would work.
 
 -}
 el : style -> List (Attribute variation msg) -> Element style variation msg -> Element style variation msg


### PR DESCRIPTION
For me as for non native English speaking person `ahve` looks like mistype. From Google I know than now it uses from time to time. But anyway...