### PR TITLE
Auto sizing attribute

### DIFF
--- a/src/Element/Attributes.elm
+++ b/src/Element/Attributes.elm
@@ -25,6 +25,7 @@ module Element.Attributes
         , px
         , fill
         , percent
+        , auto
         , vary
         , spacing
         , spacingXY
@@ -466,6 +467,11 @@ fill =
 percent : Float -> Length
 percent =
     Style.Percent
+
+{-| -}
+auto : Length
+auto =
+    Style.Auto
 
 
 {-| Apply a style variation.


### PR DESCRIPTION
Grids should have the options to adapt the size of a given row or column to the size of its contents, like this:

`{ columns = [ px 260, px 260 ]
     , rows =
          [ auto
          , px 100 ]
}`