### PR TITLE
Do not quote generic font-family keywords.

### DIFF
--- a/src/Style/Internal/Render/Value.elm
+++ b/src/Style/Internal/Render/Value.elm
@@ -3,6 +3,7 @@ module Style.Internal.Render.Value exposing (..)
 {-| -}
 
 import Color exposing (Color)
+import Set exposing (Set)
 import Style.Internal.Model as Internal exposing (..)
 
 
@@ -105,7 +106,29 @@ gridPosition (GridPosition { start, width, height }) =
                     ]
 
 
+
+
+genericFamilies : Set String
+genericFamilies =
+    Set.fromList
+        [ "serif"
+        , "sans-serif"
+        , "cursive"
+        , "fantasy"
+        , "monospace"
+        ]
+
+
+typeface : List String -> String
 typeface families =
     families
-        |> List.map (\fam -> "\"" ++ fam ++ "\"")
+        |> List.map
+            (\fam ->
+                if Set.member fam genericFamilies then
+                    -- https://www.w3.org/TR/css-fonts-3/#generic-family-value
+                    -- Generic font families are keywords and must not be quoted.
+                    fam
+                else
+                    "\"" ++ fam ++ "\""
+            )
         |> String.join ", "


### PR DESCRIPTION
See https://www.w3.org/TR/css-fonts-3/#generic-family-value:

> The following generic family keywords are defined: ‘serif’, ‘sans-serif’,
> ‘cursive’, ‘fantasy’, and ‘monospace’. These keywords can be used as a general
> fallback mechanism when an author's desired font choices are not available. As
> keywords, they must not be quoted.