### PR TITLE
add valueAttr for textareas

### DIFF
--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -505,7 +505,7 @@ textHelper kind addedOptions style attrs input =
                         { node = "textarea"
                         , style = Just style
                         , attrs =
-                            (Attr.inlineStyle [ ( "resize", "none" ) ] :: Events.onInput input.onChange :: attrs)
+                            (Attr.inlineStyle [ ( "resize", "none" ) ] :: Events.onInput input.onChange :: valueAttr input.value :: attrs)
                                 |> (withPlaceholder >> withReadonly >> withError >> addOptionsAsAttrs options)
                         , child =
                             Internal.Text


### PR DESCRIPTION
This fixes a bug where `Input.multiline` didn’t respond to external model changes.

<!--
Hi there!

Thanks for opening a PR on style-elements. We really appreciate you taking the time to put something together!

If this is a PR for a new feature, please talk with us about it in #style-elements on the Elm Slack. There may be something in progress that will suit your needs. Regardless, showing up there will make it much easier for us to merge your PR eventually. The feedback loop is faster!

If this is a small PR (like a typo fix or documentation change) know that the response may be batched and your PR may wait for a little bit.

Feel free to remove this message before submitt your PR. Thank you again for improving style-elements, and we'll talk to you soon!
-->
