### PR TITLE
Expose `Element.Input.Label` type

### DIFF
--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -3,6 +3,7 @@ module Element.Input
         ( Checkbox
         , Choice
         , ChoiceState(..)
+        , Label
         , Option
         , Radio
         , Select
@@ -17,10 +18,6 @@ module Element.Input
         , checkbox
         , choice
         , clear
-          -- , grid
-          -- , Grid
-          -- , cell
-          -- , cellWith
         , currentPassword
         , disabled
         , dropMenu
@@ -78,7 +75,7 @@ The following text inputs give hints to the browser so they can be autofilled.
 
 ## Labels
 
-@docs labelAbove, labelBelow, labelLeft, labelRight, placeholder, hiddenLabel
+@docs Label, labelAbove, labelBelow, labelLeft, labelRight, placeholder, hiddenLabel
 
 
 ## Options
@@ -654,6 +651,7 @@ type Error style variation msg
     | ErrorAbove (Element style variation msg)
 
 
+{-| -}
 type Label style variation msg
     = LabelBelow (Element style variation msg)
     | LabelAbove (Element style variation msg)


### PR DESCRIPTION
Allow to use Label type outside of the style-elements package. As the
result, it is possible to create helper functions that uses Label type
for their adnotations.

For example:

    placeholderConfig : String -> Input.Label style variation msg
    placeholderConfig placeholderText =
        Input.placeholder
            { label = Input.hiddenLabel ""
            , text = placeholderText
            }

<!--
Hi there!

Thanks for opening a PR on style-elements. We really appreciate you taking the time to put something together!

If this is a PR for a new feature, please talk with us about it in #style-elements on the Elm Slack. There may be something in progress that will suit your needs. Regardless, showing up there will make it much easier for us to merge your PR eventually. The feedback loop is faster!

If this is a small PR (like a typo fix or documentation change) know that the response may be batched and your PR may wait for a little bit.

Feel free to remove this message before submitt your PR. Thank you again for improving style-elements, and we'll talk to you soon!
-->
