### PR TITLE
Do not use a pointer cursor for the button elements by default

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -464,7 +464,7 @@ button style attrs child =
     Element
         { node = "button"
         , style = Just style
-        , attrs = Attr.class "button-focus" :: Attr.inlineStyle [ ( "cursor", "pointer" ) ] :: Attr.toAttr (Html.Attributes.tabindex 0) :: attrs
+        , attrs = Attr.class "button-focus" :: Attr.toAttr (Html.Attributes.tabindex 0) :: attrs
         , child = child
         , absolutelyPositioned = Nothing
         }


### PR DESCRIPTION
Using an inline style for the cursor makes it impossible to set
different value when needed without using `!important`. This is
a case with, for example, disabled buttons which should have
`cursor: not-allowed` style.

CSS specification for the cursor[1] says that `pointer` value
should be used for indicating a link. In many cases, the button
selector have a different role than redirecting to another
location.

[1]: https://www.w3.org/TR/css-ui-3/#cursor

<!--
Hi there!

Thanks for opening a PR on style-elements. We really appreciate you taking the time to put something together!

If this is a PR for a new feature, please talk with us about it in #style-elements on the Elm Slack. There may be something in progress that will suit your needs. Regardless, showing up there will make it much easier for us to merge your PR eventually. The feedback loop is faster!

If this is a small PR (like a typo fix or documentation change) know that the response may be batched and your PR may wait for a little bit.

Feel free to remove this message before submitt your PR. Thank you again for improving style-elements, and we'll talk to you soon!
-->
