### PR TITLE
Fix style variations documentation example

### DIFF
--- a/src/Style.elm
+++ b/src/Style.elm
@@ -80,15 +80,15 @@ Styles can have variations. Here's what it looks like to have a button style wit
 
     -- You need to create a new type to capture vartiations.
     type Variations
-            = Large
+            = Disabled
 
 
     stylesheet =
         Style.styleSheet
             [ style Button
-                [ Font.size 16
-                , variation Large
-                    [ Font.size 20
+                [ Color.background blue
+                , variation Disabled
+                    [ Color.background grey
                     ]
                 ]
             ]


### PR DESCRIPTION
The style variation documentation example compares variation and
subtyping. However, the comparison previously confused the example use
case. The mixing of "Active"/"Disabled" subtypes or the "Large" button
variation caused reader confusion and compilation failure. The
documentation now uses the same "Disabled" button example in both
places, resolving the compilation error and reader confusion.