### PR TITLE
Add Font variations to ensure normal style and weight

### DIFF
--- a/src/Style/Font.elm
+++ b/src/Style/Font.elm
@@ -17,6 +17,7 @@ module Style.Font
         , lineHeight
         , lowercase
         , monospace
+        , normal
         , sansSerif
         , serif
         , size
@@ -25,6 +26,7 @@ module Style.Font
         , underline
         , uppercase
         , weight
+        , weightNormal
         , wordSpacing
         )
 
@@ -47,7 +49,7 @@ Meant to be imported as:
 
 ## Font Styles
 
-@docs uppercase, capitalize, lowercase, underline, strike, italic, bold, weight, light
+@docs uppercase, capitalize, lowercase, underline, strike, italic, normal, bold, weight, weightNormal, light
 
 -}
 
@@ -189,10 +191,24 @@ italic =
     Internal.Font "font-style" "italic"
 
 
+{-| Reset font-style to normal from italic
+-}
+normal : Property class variation
+normal =
+    Internal.Font "font-style" "normal"
+
+
 {-| -}
 bold : Property class variation
 bold =
     Internal.Font "font-weight" "700"
+
+
+{-| Reset font-weight to normal (400)
+-}
+weightNormal : Property class variation
+weightNormal =
+    Internal.Font "font-weight" "400"
 
 
 {-| -}


### PR DESCRIPTION
In order to ensure certain attributes in a contained context, it seems like there should be a way to specify "normal" in order to override settings from the containing context. I have added variations that enable that for font-style and font-weight here:

Added 'normal' variation to reset font-style to normal from itallic
Added 'weightNormal' variation to reset font-weight to normal (400)

<!--
Hi there!

Thanks for opening a PR on style-elements. We really appreciate you taking the time to put something together!

If this is a PR for a new feature, please talk with us about it in #style-elements on the Elm Slack. There may be something in progress that will suit your needs. Regardless, showing up there will make it much easier for us to merge your PR eventually. The feedback loop is faster!

If this is a small PR (like a typo fix or documentation change) know that the response may be batched and your PR may wait for a little bit.

Feel free to remove this message before submitt your PR. Thank you again for improving style-elements, and we'll talk to you soon!
-->
