### PR TITLE
Fix background-size value name

### DIFF
--- a/src/Style/Internal/Render/Property.elm
+++ b/src/Style/Internal/Render/Property.elm
@@ -296,7 +296,7 @@ background prop =
             , ( "background-size"
               , case size of
                     Contain ->
-                        "container"
+                        "contain"
 
                     Cover ->
                         "cover"


### PR DESCRIPTION
Should be `contain` instead of `container`