### PR TITLE
Add date field to Element.Input

### DIFF
--- a/examples/Form.elm
+++ b/examples/Form.elm
@@ -114,6 +114,7 @@ main =
             ( { checkbox = False
               , lunch = Taco
               , text = "hi"
+              , date = ""
               , manyLunches = [ Taco, Burrito ]
               , openMenu = False
               , search = Input.autocomplete Nothing Search
@@ -131,6 +132,7 @@ type Msg
     = Check Bool
     | ChooseLunch Lunch
     | ChangeText String
+    | ChangeDate String
     | UpdateLunches (List Lunch)
     | ShowMenu Bool
     | Search (Input.SelectMsg Lunch)
@@ -156,6 +158,11 @@ update msg model =
 
         ChangeText str ->
             ( { model | text = str }
+            , Cmd.none
+            )
+
+        ChangeDate str ->
+            ( { model | date = str }
             , Cmd.none
             )
 
@@ -198,6 +205,15 @@ view model =
                             }
                     , options =
                         [ Input.errorBelow (el Error [] (text "This is an Error!"))
+                        ]
+                    }
+                , Input.date Field []
+                    { onChange = ChangeDate
+                    , value = model.date
+                    , label =
+                        Input.labelLeft (el None [] (text "Date"))
+                    , options =
+                        [ Input.errorBelow (el Error [] (text "This is a date Error!"))
                         ]
                     }
                 , Input.checkbox Checkbox

--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -23,6 +23,7 @@ module Element.Input
           -- , cell
           -- , cellWith
         , currentPassword
+        , date
         , disabled
         , dropMenu
         , email
@@ -61,7 +62,7 @@ module Element.Input
 
 ## Text Input
 
-@docs Text, text, multiline, search, email
+@docs Text, text, multiline, search, email, date
 
 The following text inputs give hints to the browser so they can be autofilled.
 
@@ -361,6 +362,7 @@ type TextKind
     | Password
     | Email
     | TextArea
+    | Date
 
 
 {-| -}
@@ -407,6 +409,12 @@ email =
 multiline : style -> List (Attribute variation msg) -> Text style variation msg -> Element style variation msg
 multiline =
     textHelper TextArea []
+
+
+{-| -}
+date : style -> List (Attribute variation msg) -> Text style variation msg -> Element style variation msg
+date =
+    textHelper Date []
 
 
 {-| -}
@@ -527,6 +535,9 @@ textHelper kind addedOptions style attrs input =
 
                 TextArea ->
                     "text"
+
+                Date ->
+                    "date"
 
         withAutofocus attrs =
             if List.any ((==) FocusOnLoad) options then


### PR DESCRIPTION
This is a pretty minimal addition to support the native `<input type="date">` HTML5 field. I didn't attempt to add any kind of parsing or validation to the input, just whatever the browser itself enforces.

Thanks for the library, I really like the style of development it enables.