### PR TITLE
Update dependency reference of the `murmur` package

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -23,12 +23,12 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "Skinney/murmur3": "2.0.7 <= v < 3.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
-        "elm/virtual-dom": "1.0.0 <= v < 2.0.0"
+        "elm/virtual-dom": "1.0.0 <= v < 2.0.0",
+        "robinheghan/murmur3": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {}
 }


### PR DESCRIPTION
Hi there @mdgriffith 👋 

Seems like [the author of `murmur` has a new GitHub account](https://github.com/robinheghan/murmur3/issues/5) and the old zipball is invalidated.

I discovered this while trying to install `elm-explorations/benchmark`, which has a direct dependency on `style-elements`.

<img width="724" alt="CleanShot 2020-09-20 at 08 12 30@2x" src="https://user-images.githubusercontent.com/9790196/93704937-0e3f3900-fb19-11ea-9752-121428272d13.png">


I've seen you have a new project, and [they are discussing to rewrite the UI section of `elm-explorations/benchmark`](https://github.com/elm-explorations/benchmark/issues/21), but I thought it'd be nice to fix the current state as well.

---

**PS**: I'm an Elm noob, I came there while reading [Programming Elm](https://programming-elm.com), please let me know if there's anything else needs to be done.

Thanks 🙏 