### PR TITLE
Fix murmur3 missing package error.

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -23,7 +23,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "Skinney/murmur3": "2.0.7 <= v < 3.0.0",
+        "robinheghan/murmur3": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",


### PR DESCRIPTION
I got an error installing `elm-benchmark` because [it still depends on this package](https://package.elm-lang.org/packages/elm-explorations/benchmark/latest/about) (hasn't upgraded to `elm-ui` yet). And this package depends on `Skinney/murmur3`, which [no longer exists](https://discourse.elm-lang.org/t/skinney-murmur3-not-downloading/6285) under that username.

If you're up for deploying a quick patch, I'd appreciate it as this would fix my CI!